### PR TITLE
feat: GA4 で本店へのCTAクリックとカスタマイズ遷移を計測

### DIFF
--- a/src/Sections/Custom/Custom.tsx
+++ b/src/Sections/Custom/Custom.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react'
 import { motion, useScroll, useTransform } from 'framer-motion'
 import { AnimatedTargetButton } from '@/components/AnimatedTargetButton'
 import { features } from './featuresData'
+import { trackOutboundClick } from '@/lib/analytics'
 
 export const CustomOrderSection = () => {
   const containerRef = useRef<HTMLDivElement>(null)
@@ -87,9 +88,14 @@ export const CustomOrderSection = () => {
           transition={{ duration: 1.2 }}
           className="mt-24 text-center"
         >
-          <AnimatedTargetButton 
+          <AnimatedTargetButton
             triggerOnScroll={true}
             href="https://sakuya-kyudogu.jp/order_made"
+            onClick={() => trackOutboundClick({
+              url: 'https://sakuya-kyudogu.jp/order_made',
+              location: 'custom',
+              label: 'カスタムオーダーを始める',
+            })}
           >
             カスタムオーダーを始める
           </AnimatedTargetButton>

--- a/src/Sections/Gallery/GalleryModal.tsx
+++ b/src/Sections/Gallery/GalleryModal.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image'
 import { GalleryImage } from './galleryData'
 import { AnimatedTargetButton } from '@/components/AnimatedTargetButton'
 import { useEffect, useCallback, useRef, useState } from 'react'
+import { trackOutboundClick } from '@/lib/analytics'
 
 interface GalleryModalProps {
   isOpen: boolean
@@ -239,7 +240,16 @@ export const GalleryModal = ({ isOpen, onClose, image }: GalleryModalProps) => {
                     <AnimatedTargetButton
                       href={image.orderUrl || "https://sakuya-kyudogu.jp/order_made/kinteki/full/parts"}
                       target="_blank"
-                      onClick={onClose}
+                      onClick={() => {
+                        if (image) {
+                          trackOutboundClick({
+                            url: image.orderUrl || "https://sakuya-kyudogu.jp/order_made/kinteki/full/parts",
+                            location: 'gallery',
+                            label: `この矢を作ってみる（${image.title}）`,
+                          });
+                        }
+                        onClose();
+                      }}
                       className="scale-75"
                       triggerOnScroll={true}
                     >
@@ -353,7 +363,16 @@ export const GalleryModal = ({ isOpen, onClose, image }: GalleryModalProps) => {
                     <AnimatedTargetButton
                       href={image.orderUrl || "https://sakuya-kyudogu.jp/order_made/kinteki/full/parts"}
                       target="_blank"
-                      onClick={onClose}
+                      onClick={() => {
+                        if (image) {
+                          trackOutboundClick({
+                            url: image.orderUrl || "https://sakuya-kyudogu.jp/order_made/kinteki/full/parts",
+                            location: 'gallery',
+                            label: `この矢を作ってみる（${image.title}）`,
+                          });
+                        }
+                        onClose();
+                      }}
                       className="scale-75"
                       triggerOnScroll={true}
                     >

--- a/src/Sections/NewArrival/NewArrival.tsx
+++ b/src/Sections/NewArrival/NewArrival.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion'
 import { HiOutlineArrowTopRightOnSquare } from 'react-icons/hi2'
 import { NewArrivalContent } from './NewArrivalContent'
 import { HiArrowDown } from 'react-icons/hi'
+import { trackOutboundClick } from '@/lib/analytics'
 
 export const NewArrival = () => {
   return (
@@ -32,6 +33,11 @@ export const NewArrival = () => {
               href="https://sakuya-kyudogu.jp/order_made?rid=69"
               target="_blank"
               rel="noopener noreferrer"
+              onClick={() => trackOutboundClick({
+                url: 'https://sakuya-kyudogu.jp/order_made?rid=69',
+                location: 'newarrival',
+                label: 'カスタマイズしてみる（新商品1: kasuo2）',
+              })}
               className="absolute inset-x-0 bottom-0 flex items-center justify-center p-3"
             >
               <div className="bg-white/90 text-[#C84C38] px-3 py-1 text-xs sm:text-sm md:text-base md:px-5 md:py-2 rounded-full font-medium flex items-center gap-1 md:gap-2 transform group-hover:scale-105 transition-all duration-300 shadow-lg border border-[#C84C38]/10 whitespace-nowrap">
@@ -53,6 +59,11 @@ export const NewArrival = () => {
               href="https://sakuya-kyudogu.jp/order_made?rid=70"
               target="_blank"
               rel="noopener noreferrer"
+              onClick={() => trackOutboundClick({
+                url: 'https://sakuya-kyudogu.jp/order_made?rid=70',
+                location: 'newarrival',
+                label: 'カスタマイズしてみる（新商品2: komonnami）',
+              })}
               className="absolute inset-x-0 bottom-0 flex items-center justify-center p-3"
             >
               <div className="bg-white/90 text-[#C84C38] px-3 py-1 text-xs sm:text-sm md:text-base md:px-5 md:py-2 rounded-full font-medium flex items-center gap-1 md:gap-2 transform group-hover:scale-105 transition-all duration-300 shadow-lg border border-[#C84C38]/10 whitespace-nowrap">

--- a/src/Sections/Other/OtherSection.tsx
+++ b/src/Sections/Other/OtherSection.tsx
@@ -4,6 +4,7 @@ import { PrimaryButton } from '@/components/PrimaryButton';
 import { Other } from './Other';
 import { FlipCard } from './FlipCard';
 import { useEffect, useState } from 'react';
+import { trackOutboundClick } from '@/lib/analytics';
 
 export const OtherSection = () => {
   const customItems = [
@@ -93,10 +94,15 @@ export const OtherSection = () => {
               transition={{ duration: 0.8, delay: 0.6 }}
               className="flex justify-center md:justify-start"
             >
-              <PrimaryButton 
+              <PrimaryButton
                 href="https://sakuya-kyudogu.jp/select_guide"
                 target="_blank"
                 icon={<HiOutlineAcademicCap className="w-6 h-6" />}
+                onClick={() => trackOutboundClick({
+                  url: 'https://sakuya-kyudogu.jp/select_guide',
+                  location: 'other',
+                  label: '矢の選び方を学ぶ',
+                })}
               >
                 矢の選び方を学ぶ　
               </PrimaryButton>

--- a/src/Sections/Ranking/Ranking.tsx
+++ b/src/Sections/Ranking/Ranking.tsx
@@ -2,6 +2,7 @@ import { motion } from 'framer-motion';
 import { RankingSection } from './RankingSection';
 import { rankingData } from './rankingData';
 import { AnimatedTargetButton } from '@/components/AnimatedTargetButton';
+import { trackOutboundClick } from '@/lib/analytics';
 
 export const Ranking: React.FC = () => {
   return (
@@ -73,6 +74,11 @@ export const Ranking: React.FC = () => {
           <AnimatedTargetButton
             triggerOnScroll={true}
             href="https://sakuya-kyudogu.jp/order_made/"
+            onClick={() => trackOutboundClick({
+              url: 'https://sakuya-kyudogu.jp/order_made/',
+              location: 'ranking',
+              label: 'オーダーメイドを始める',
+            })}
           >
             オーダーメイドを始める
           </AnimatedTargetButton>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image'
 import { GiArrowhead } from 'react-icons/gi'
 import { FiShoppingCart, FiMail, FiInstagram } from 'react-icons/fi'
 import { RiTwitterXLine } from 'react-icons/ri'
+import { trackOutboundClick } from '@/lib/analytics'
 
 interface MenuItem {
   label: string
@@ -94,21 +95,30 @@ export const Footer = () => {
   }, [isMounted])
 
   // リンクに対するイベントハンドラー
-  const handleLinkClick = useCallback((e: React.MouseEvent | React.TouchEvent, url?: string) => {
+  const handleLinkClick = useCallback((e: React.MouseEvent | React.TouchEvent, url?: string, label?: string) => {
     e.preventDefault()
     e.stopPropagation()
-    
+
     // 既に処理中なら何もしない
     if (isProcessingRef.current) return
-    
+
     // 処理中フラグを立てる
     isProcessingRef.current = true
-    
+
     if (url) {
+      // 本店（sakuya-kyudogu.jp）への遷移は GA4 に計測イベントを送る
+      if (url.includes('sakuya-kyudogu.jp')) {
+        trackOutboundClick({
+          url,
+          location: 'footer',
+          label: label ?? url,
+        })
+      }
+
       // setTimeout を使用して非同期でリンクを開く
       setTimeout(() => {
         window.open(url, '_blank', 'noopener,noreferrer')
-        
+
         // 処理が完了したらフラグをリセット
         setTimeout(() => {
           isProcessingRef.current = false
@@ -143,15 +153,15 @@ export const Footer = () => {
       : undefined
   }, [isTouchDevice, scrollToSection])
   
-  const getLinkClickHandler = useCallback((url?: string) => {
-    return isTouchDevice 
-      ? undefined 
-      : (e: React.MouseEvent) => handleLinkClick(e, url)
+  const getLinkClickHandler = useCallback((url?: string, label?: string) => {
+    return isTouchDevice
+      ? undefined
+      : (e: React.MouseEvent) => handleLinkClick(e, url, label)
   }, [isTouchDevice, handleLinkClick])
-  
-  const getLinkTouchHandler = useCallback((url?: string) => {
-    return isTouchDevice 
-      ? (e: React.TouchEvent) => handleLinkClick(e, url) 
+
+  const getLinkTouchHandler = useCallback((url?: string, label?: string) => {
+    return isTouchDevice
+      ? (e: React.TouchEvent) => handleLinkClick(e, url, label)
       : undefined
   }, [isTouchDevice, handleLinkClick])
 
@@ -208,8 +218,8 @@ export const Footer = () => {
                 href="https://sakuya-kyudogu.jp/order_made"
                 target="_blank"
                 rel="noopener noreferrer"
-                onClick={getLinkClickHandler("https://sakuya-kyudogu.jp/order_made")}
-                onTouchEnd={getLinkTouchHandler("https://sakuya-kyudogu.jp/order_made")}
+                onClick={getLinkClickHandler("https://sakuya-kyudogu.jp/order_made", "オーダーする（CTA）")}
+                onTouchEnd={getLinkTouchHandler("https://sakuya-kyudogu.jp/order_made", "オーダーする（CTA）")}
                 className="px-6 py-3 bg-[#C84C38] text-white rounded-lg text-sm font-medium hover:bg-[#C84C38]/90 transition-colors duration-200 flex items-center justify-center"
                 style={{ touchAction: 'manipulation' }}
               >
@@ -244,8 +254,8 @@ export const Footer = () => {
                 href="https://sakuya-kyudogu.jp"
                 target="_blank"
                 rel="noopener noreferrer"
-                onClick={getLinkClickHandler("https://sakuya-kyudogu.jp")}
-                onTouchEnd={getLinkTouchHandler("https://sakuya-kyudogu.jp")}
+                onClick={getLinkClickHandler("https://sakuya-kyudogu.jp", "咲矢弓道具 公式サイト")}
+                onTouchEnd={getLinkTouchHandler("https://sakuya-kyudogu.jp", "咲矢弓道具 公式サイト")}
                 className="text-sm text-gray-600 hover:text-[#C84C38] transition-colors duration-200 flex items-center justify-center md:justify-start"
                 style={{ touchAction: 'manipulation' }}
               >
@@ -255,8 +265,8 @@ export const Footer = () => {
                 href="https://sakuya-kyudogu.jp/order_made"
                 target="_blank"
                 rel="noopener noreferrer"
-                onClick={getLinkClickHandler("https://sakuya-kyudogu.jp/order_made")}
-                onTouchEnd={getLinkTouchHandler("https://sakuya-kyudogu.jp/order_made")}
+                onClick={getLinkClickHandler("https://sakuya-kyudogu.jp/order_made", "矢のオーダーメイドシステム")}
+                onTouchEnd={getLinkTouchHandler("https://sakuya-kyudogu.jp/order_made", "矢のオーダーメイドシステム")}
                 className="text-sm text-gray-600 hover:text-[#C84C38] transition-colors duration-200 flex items-center justify-center md:justify-start "
                 style={{ touchAction: 'manipulation' }}
               >
@@ -266,8 +276,8 @@ export const Footer = () => {
                 href="https://sakuya-kyudogu.jp/select_guide"
                 target="_blank"
                 rel="noopener noreferrer"
-                onClick={getLinkClickHandler("https://sakuya-kyudogu.jp/select_guide")}
-                onTouchEnd={getLinkTouchHandler("https://sakuya-kyudogu.jp/select_guide")}
+                onClick={getLinkClickHandler("https://sakuya-kyudogu.jp/select_guide", "矢の選び方")}
+                onTouchEnd={getLinkTouchHandler("https://sakuya-kyudogu.jp/select_guide", "矢の選び方")}
                 className="text-sm text-gray-600 hover:text-[#C84C38] transition-colors duration-200 flex items-center justify-center md:justify-start"
                 style={{ touchAction: 'manipulation' }}
               >
@@ -278,8 +288,8 @@ export const Footer = () => {
                 href="https://sakuya-kyudogu.jp/contact"
                 target="_blank"
                 rel="noopener noreferrer"
-                onClick={getLinkClickHandler("https://sakuya-kyudogu.jp/contact")}
-                onTouchEnd={getLinkTouchHandler("https://sakuya-kyudogu.jp/contact")}
+                onClick={getLinkClickHandler("https://sakuya-kyudogu.jp/contact", "お問い合わせ")}
+                onTouchEnd={getLinkTouchHandler("https://sakuya-kyudogu.jp/contact", "お問い合わせ")}
                 className="text-sm text-gray-600 hover:text-[#C84C38] transition-colors duration-200 flex items-center justify-center md:justify-start"
                 style={{ touchAction: 'manipulation' }}
               >

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,6 +6,7 @@ import { GiArrowhead } from 'react-icons/gi'
 import { FiShoppingCart, FiMail, FiInstagram, FiMenu, FiX } from 'react-icons/fi'
 import { RiTwitterXLine } from 'react-icons/ri'
 import { createPortal } from 'react-dom'
+import { trackOutboundClick } from '@/lib/analytics'
 
 interface MenuItem {
   label: string
@@ -330,9 +331,14 @@ export const Header = () => {
                   href="https://sakuya-kyudogu.jp/select_guide"
                   target="_blank"
                   rel="noopener noreferrer"
+                  onClick={() => trackOutboundClick({
+                    url: 'https://sakuya-kyudogu.jp/select_guide',
+                    location: 'header',
+                    label: '矢の選び方',
+                  })}
                   className={`relative py-2 mr-8 text-xs lg:text-sm font-medium transition-colors duration-200 hidden md:flex items-center whitespace-nowrap
-                    ${isScrolled 
-                      ? 'text-[#333333] hover:text-[#C84C38]' 
+                    ${isScrolled
+                      ? 'text-[#333333] hover:text-[#C84C38]'
                       : 'text-[#333333]/90 hover:text-[#333333]'
                     }
                   `}
@@ -345,9 +351,14 @@ export const Header = () => {
                   href="https://sakuya-kyudogu.jp/contact"
                   target="_blank"
                   rel="noopener noreferrer"
+                  onClick={() => trackOutboundClick({
+                    url: 'https://sakuya-kyudogu.jp/contact',
+                    location: 'header',
+                    label: 'お問い合わせ',
+                  })}
                   className={`relative py-2 mr-6 text-xs lg:text-sm font-medium transition-colors duration-200 hidden md:flex items-center whitespace-nowrap
-                    ${isScrolled 
-                      ? 'text-[#333333] hover:text-[#C84C38]' 
+                    ${isScrolled
+                      ? 'text-[#333333] hover:text-[#C84C38]'
                       : 'text-[#333333]/90 hover:text-[#333333]'
                     }
                   `}
@@ -360,6 +371,11 @@ export const Header = () => {
                   href="https://sakuya-kyudogu.jp/order_made"
                   target="_blank"
                   rel="noopener noreferrer"
+                  onClick={() => trackOutboundClick({
+                    url: 'https://sakuya-kyudogu.jp/order_made',
+                    location: 'header',
+                    label: 'オーダーする',
+                  })}
                   style={{
                     background: '#C84C38',
                     color: 'white',
@@ -543,23 +559,25 @@ export const Header = () => {
                         rel="noopener noreferrer"
                         className="relative px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200 text-left cursor-pointer touch-manipulation tap-highlight-none flex items-center text-[#333333] hover:bg-gray-100"
                         onClick={(e) => {
-                          // デフォルトの動作を防止
                           e.preventDefault();
-                          // イベントの伝播を停止
                           e.stopPropagation();
-                          // メニューを閉じる
+                          trackOutboundClick({
+                            url: 'https://sakuya-kyudogu.jp/select_guide',
+                            location: 'header_mobile',
+                            label: '矢の選び方',
+                          });
                           closeMenu();
-                          // リンクを開く
                           window.open("https://sakuya-kyudogu.jp/select_guide", "_blank", "noopener,noreferrer");
                         }}
                         onTouchEnd={(e) => {
-                          // デフォルトの動作を防止
                           e.preventDefault();
-                          // イベントの伝播を停止
                           e.stopPropagation();
-                          // メニューを閉じる
+                          trackOutboundClick({
+                            url: 'https://sakuya-kyudogu.jp/select_guide',
+                            location: 'header_mobile',
+                            label: '矢の選び方',
+                          });
                           closeMenu();
-                          // リンクを開く
                           window.open("https://sakuya-kyudogu.jp/select_guide", "_blank", "noopener,noreferrer");
                         }}
                         style={{ touchAction: 'manipulation' }}
@@ -573,23 +591,25 @@ export const Header = () => {
                         rel="noopener noreferrer"
                         className="relative px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200 text-left cursor-pointer touch-manipulation tap-highlight-none flex items-center text-[#333333] hover:bg-gray-100"
                         onClick={(e) => {
-                          // デフォルトの動作を防止
                           e.preventDefault();
-                          // イベントの伝播を停止
                           e.stopPropagation();
-                          // メニューを閉じる
+                          trackOutboundClick({
+                            url: 'https://sakuya-kyudogu.jp/contact',
+                            location: 'header_mobile',
+                            label: 'お問い合わせ',
+                          });
                           closeMenu();
-                          // リンクを開く
                           window.open("https://sakuya-kyudogu.jp/contact", "_blank", "noopener,noreferrer");
                         }}
                         onTouchEnd={(e) => {
-                          // デフォルトの動作を防止
                           e.preventDefault();
-                          // イベントの伝播を停止
                           e.stopPropagation();
-                          // メニューを閉じる
+                          trackOutboundClick({
+                            url: 'https://sakuya-kyudogu.jp/contact',
+                            location: 'header_mobile',
+                            label: 'お問い合わせ',
+                          });
                           closeMenu();
-                          // リンクを開く
                           window.open("https://sakuya-kyudogu.jp/contact", "_blank", "noopener,noreferrer");
                         }}
                         style={{ touchAction: 'manipulation' }}
@@ -603,23 +623,25 @@ export const Header = () => {
                         rel="noopener noreferrer"
                         className="relative px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200 text-left cursor-pointer touch-manipulation tap-highlight-none flex items-center bg-[#C84C38]/10 text-[#C84C38] font-bold hover:bg-[#C84C38]/20"
                         onClick={(e) => {
-                          // デフォルトの動作を防止
                           e.preventDefault();
-                          // イベントの伝播を停止
                           e.stopPropagation();
-                          // メニューを閉じる
+                          trackOutboundClick({
+                            url: 'https://sakuya-kyudogu.jp/order_made',
+                            location: 'header_mobile',
+                            label: 'オーダーする',
+                          });
                           closeMenu();
-                          // リンクを開く
                           window.open("https://sakuya-kyudogu.jp/order_made", "_blank", "noopener,noreferrer");
                         }}
                         onTouchEnd={(e) => {
-                          // デフォルトの動作を防止
                           e.preventDefault();
-                          // イベントの伝播を停止
                           e.stopPropagation();
-                          // メニューを閉じる
+                          trackOutboundClick({
+                            url: 'https://sakuya-kyudogu.jp/order_made',
+                            location: 'header_mobile',
+                            label: 'オーダーする',
+                          });
                           closeMenu();
-                          // リンクを開く
                           window.open("https://sakuya-kyudogu.jp/order_made", "_blank", "noopener,noreferrer");
                         }}
                         style={{ touchAction: 'manipulation' }}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,66 @@
+/**
+ * Analytics 計測ユーティリティ
+ *
+ * gallery LP から本店 sakuya-kyudogu.jp への遷移をGA4で計測するための関数群。
+ * GTMコンテナ経由ではなく、直接 dataLayer.push / gtag を呼ぶ方式。
+ *
+ * 計測されるイベント:
+ *   - cta_click_to_main: 本店（sakuya-kyudogu.jp）へのCTAクリック
+ */
+
+type CtaLocation =
+  | 'header'
+  | 'header_mobile'
+  | 'footer'
+  | 'ranking'
+  | 'custom'
+  | 'other'
+  | 'newarrival';
+
+interface TrackOutboundClickParams {
+  /** 遷移先URL */
+  url: string;
+  /** CTAが配置されている場所の識別子 */
+  location: CtaLocation;
+  /** CTAのラベル（例: 'オーダーする', '矢の選び方'） */
+  label: string;
+}
+
+/**
+ * 本店（sakuya-kyudogu.jp）へのCTAクリックを GA4 に送信する。
+ *
+ * GA4 の標準イベントではなくカスタムイベント `cta_click_to_main` として送信。
+ * この名前で GA4 → 探索 → 自由形式 で集計できる。
+ */
+export const trackOutboundClick = (params: TrackOutboundClickParams) => {
+  if (typeof window === 'undefined') return;
+
+  const destinationPath = (() => {
+    try {
+      return new URL(params.url).pathname;
+    } catch {
+      return params.url;
+    }
+  })();
+
+  // dataLayer 経由（GTM 連携を将来的に取りやすい）
+  if (Array.isArray(window.dataLayer)) {
+    window.dataLayer.push({
+      event: 'cta_click_to_main',
+      cta_location: params.location,
+      cta_label: params.label,
+      destination_url: params.url,
+      destination_path: destinationPath,
+    });
+  }
+
+  // gtag 直接呼び出し（GTM が停止していても発火させるためのフォールバック）
+  if (typeof window.gtag === 'function') {
+    window.gtag('event', 'cta_click_to_main', {
+      cta_location: params.location,
+      cta_label: params.label,
+      destination_url: params.url,
+      destination_path: destinationPath,
+    });
+  }
+};

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -6,6 +6,14 @@
  *
  * 計測されるイベント:
  *   - cta_click_to_main: 本店（sakuya-kyudogu.jp）へのCTAクリック
+ *
+ * イベントパラメータ:
+ *   - cta_location: CTAが配置されている場所
+ *   - cta_label: CTAのラベル
+ *   - destination_url: 遷移先URL（クエリパラメータ含む）
+ *   - destination_path: 遷移先パス
+ *   - is_customized: カスタマイズ済みデザイン経由かどうか（?rid=XX が付与されている場合 true）
+ *   - customization_id: カスタマイズID（rid 値、未指定時は undefined）
  */
 
 type CtaLocation =
@@ -15,16 +23,44 @@ type CtaLocation =
   | 'ranking'
   | 'custom'
   | 'other'
-  | 'newarrival';
+  | 'newarrival'
+  | 'gallery';
 
 interface TrackOutboundClickParams {
-  /** 遷移先URL */
+  /** 遷移先URL（?rid=XX 等のクエリパラメータが付いていれば自動的にカスタマイズ判定する） */
   url: string;
   /** CTAが配置されている場所の識別子 */
   location: CtaLocation;
-  /** CTAのラベル（例: 'オーダーする', '矢の選び方'） */
+  /** CTAのラベル（例: 'オーダーする', 'この矢を作ってみる'） */
   label: string;
 }
+
+/**
+ * URL から「カスタマイズ済みデザインかどうか」と「カスタマイズID（rid）」を抽出する。
+ *
+ * 判定ルール:
+ *   - `?rid=XX` パラメータが付いていれば「カスタマイズ済み」(is_customized=true)
+ *   - `/order_made/kinteki/full/parts` のような詳細パスへの遷移も「カスタマイズ意図」とみなす
+ */
+const detectCustomization = (url: string): {
+  is_customized: boolean;
+  customization_id?: string;
+} => {
+  try {
+    const u = new URL(url);
+    const rid = u.searchParams.get('rid');
+    if (rid) {
+      return { is_customized: true, customization_id: rid };
+    }
+    // rid なしでも /parts などへ直接飛ぶ場合は「カスタマイズ意図あり」と判定
+    if (u.pathname.includes('/order_made/kinteki/full/parts')) {
+      return { is_customized: true };
+    }
+    return { is_customized: false };
+  } catch {
+    return { is_customized: false };
+  }
+};
 
 /**
  * 本店（sakuya-kyudogu.jp）へのCTAクリックを GA4 に送信する。
@@ -43,24 +79,30 @@ export const trackOutboundClick = (params: TrackOutboundClickParams) => {
     }
   })();
 
+  const { is_customized, customization_id } = detectCustomization(params.url);
+
+  const eventParams: Record<string, unknown> = {
+    cta_location: params.location,
+    cta_label: params.label,
+    destination_url: params.url,
+    destination_path: destinationPath,
+    is_customized,
+  };
+
+  if (customization_id !== undefined) {
+    eventParams.customization_id = customization_id;
+  }
+
   // dataLayer 経由（GTM 連携を将来的に取りやすい）
   if (Array.isArray(window.dataLayer)) {
     window.dataLayer.push({
       event: 'cta_click_to_main',
-      cta_location: params.location,
-      cta_label: params.label,
-      destination_url: params.url,
-      destination_path: destinationPath,
+      ...eventParams,
     });
   }
 
   // gtag 直接呼び出し（GTM が停止していても発火させるためのフォールバック）
   if (typeof window.gtag === 'function') {
-    window.gtag('event', 'cta_click_to_main', {
-      cta_location: params.location,
-      cta_label: params.label,
-      destination_url: params.url,
-      destination_path: destinationPath,
-    });
+    window.gtag('event', 'cta_click_to_main', eventParams);
   }
 };


### PR DESCRIPTION
## Summary

LP（gallery.sakuya-kyudogu.jp）から本店（sakuya-kyudogu.jp）へのCTAクリックを GA4 で計測できるようにします。

これまで本店遷移は GA4 の `click` イベントとして十分に記録されていなかったため、Gallery LP 経由でどれだけ本店に誘導できているか（また、その中でカスタマイズ済みデザインの効果はどれくらいか）を可視化します。

## 変更内容

### 新規: `src/lib/analytics.ts`
共通計測ユーティリティ `trackOutboundClick`。

- `gtag()` 直接呼び出し + `dataLayer.push()` の両方で発火（GTM コンテナの状態に依存しない）
- URL から `?rid=XX` パラメータを自動検出して `is_customized` / `customization_id` をイベントに付与
- `/order_made/kinteki/full/parts` への直接遷移も「カスタマイズ意図あり」と判定

### 計測タグの追加 全19箇所

| 配置 | 件数 | 通常 / カスタマイズ |
|---|---|---|
| Header（PC + モバイル） | 6 | 通常 |
| Footer | 5 | 通常 |
| Ranking | 1 | 通常 |
| Custom セクション | 1 | 通常 |
| Other セクション | 1 | 通常 |
| NewArrival（rid=69, rid=70） | 2 | カスタマイズ済み |
| GalleryModal（「この矢を作ってみる」 × PC/SP） | 2 | カスタマイズ済み |

## 計測されるイベント

イベント名: `cta_click_to_main`

### 必ず付与
- `cta_location`: 配置場所（header / footer / gallery 等）
- `cta_label`: CTA のラベル
- `destination_url`: 遷移先URL（クエリ含む）
- `destination_path`: 遷移先パス
- `is_customized`: カスタマイズ済みデザイン経由かどうか

### カスタマイズ時のみ
- `customization_id`: rid 値（例 `"52"`、`"69"`）

## GA4 で確認できる新しい指標

- **カスタマイズ経由の遷移率**：`is_customized` でディメンション分割
- **人気のカスタマイズID**：`customization_id` 別のイベント数
- **配置場所別の効果**：`cta_location` × `is_customized` のクロス集計

## Test plan

- [ ] `npm run build` がパス（確認済み）
- [ ] TypeScript 型チェックがパス（確認済み）
- [ ] ESLint チェック（既存の Warning のみ、新規指摘なし）
- [ ] 本番デプロイ後、GA4 リアルタイムレポートで `cta_click_to_main` イベントが発火することを確認
- [ ] 各 location（header / footer / gallery / newarrival 等）から発火することを目視確認
- [ ] `?rid=XX` 付きリンク（NewArrival, GalleryModal）で `is_customized=true` および `customization_id` が記録されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)