### PR TITLE
fix: gtag.js を直接読み込んでカスタムイベントを GA4 に届ける

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -114,7 +114,40 @@ export default function App({ Component, pageProps }: AppProps) {
           />
         </noscript>
       )}
-      
+
+      {/*
+        GA4 直接読み込み（gtag.js）
+
+        GTM-MHS6M7DV コンテナ内のタグが「停止状態」のため、
+        本店CTAクリック等のカスタムイベント（cta_click_to_main）が GA4 に届かない。
+        gtag.js を直接読み込んで window.gtag を定義し、確実に送信できるようにする。
+
+        send_page_view: false で page_view の二重送信を防止
+        （page_view は GTM 経由で既に送信されている）
+      */}
+      {process.env.NODE_ENV === 'production' && (
+        <>
+          <Script
+            id="ga4-bootstrap"
+            strategy="afterInteractive"
+            src="https://www.googletagmanager.com/gtag/js?id=G-THSQWDTECK"
+          />
+          <Script
+            id="ga4-init"
+            strategy="afterInteractive"
+            dangerouslySetInnerHTML={{
+              __html: `
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                window.gtag = gtag;
+                gtag('js', new Date());
+                gtag('config', 'G-THSQWDTECK', { send_page_view: false });
+              `,
+            }}
+          />
+        </>
+      )}
+
       <Header />
       <Component {...pageProps} />
       <Footer />


### PR DESCRIPTION
## 背景

PR #32 で `cta_click_to_main` イベントの計測実装を入れたが、本番で実際に CTA をクリックしても GA4 リアルタイムレポートに記録されないことが判明。

調査の結果、以下の状態だった:
- `window.gtag` が **undefined** （GTM コンテナ内に gtag.js を発火するタグが存在しない）
- `dataLayer.push` は実行されているが、GTM コンテナ内のタグが「停止状態」のため GA4 に転送されない
- 結果、`gtag()` 経由・`dataLayer.push` 経由のいずれも GA4 まで届いていなかった

## 修正内容

`_app.tsx` に gtag.js の直接読み込みを追加。

```tsx
<Script
  id="ga4-bootstrap"
  strategy="afterInteractive"
  src="https://www.googletagmanager.com/gtag/js?id=G-THSQWDTECK"
/>
<Script
  id="ga4-init"
  strategy="afterInteractive"
  dangerouslySetInnerHTML={{
    __html: `
      window.dataLayer = window.dataLayer || [];
      function gtag(){dataLayer.push(arguments);}
      window.gtag = gtag;
      gtag('js', new Date());
      gtag('config', 'G-THSQWDTECK', { send_page_view: false });
    `,
  }}
/>
```

### ポイント

- **`window.gtag` を確実に定義**：これにより `trackOutboundClick` 内の `gtag('event', ...)` 呼び出しが動作
- **`send_page_view: false`**：page_view は GTM 経由で既に送られているので二重送信を回避
- **本番環境のみ**：`process.env.NODE_ENV === 'production'` でガード

## 期待する効果

- `cta_click_to_main` イベントが GA4 リアルタイムレポートに反映
- カスタマイズ済みリンク（rid=XX）の `is_customized` / `customization_id` が集計可能に
- 既存の page_view 計測には影響しない（GTM 経由で継続）

## Test plan

- [ ] `npm run build` がパス（確認済み）
- [ ] TypeScript 型チェックがパス（確認済み）
- [ ] 本番デプロイ後、ブラウザで `window.gtag` が `function` として存在することを確認
- [ ] CTA をクリックして GA4 リアルタイムレポートに `cta_click_to_main` が表示されることを確認
- [ ] page_view が二重送信されていないこと（GA4 のリアルタイムでイベント数が異常に増えていないこと）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)